### PR TITLE
style page signer un contrat

### DIFF
--- a/app/Resources/views/apprenti/contrat.html.twig
+++ b/app/Resources/views/apprenti/contrat.html.twig
@@ -2,49 +2,46 @@
 
 {% block body %}
     <div id="activeTab" data-active="apprenti" class="container-fluid">
-        <div class="section-title background-apprenti"></div>
+        <div class=" row d-none d-sm-block">
+            <div class="section-title background-apprenti"></div>
+        </div>
         <div class="row">
-            <div class="col-md-12 col-sm-12">
-                <h1 class="title-style style-page">L'apprentissage: signer un contrat</h1>
+            <div class="col offset-md-1">
+                <h1 class=" my-5 style-page">L'apprentissage: signer un contrat</h1>
             </div>
-            <div class="col-md-10 offset-1 my-5">
-                <p>
-                    Vous avez réfléchi et fait le choix d'une formation en rapport avec vos motivations personnelles.
+        </div>
+        <div class="row">
+            <div class="col-md-10 offset-1 my-md-2">
+                <p>Vous avez réfléchi et fait le choix d'une formation en rapport avec vos motivations personnelles.
                     Vous vous sentez disponible pour vous impliquer professionnellement, tout en menant de front vos études.
                     À ce stade, vous êtes prêt(e) à rencontrer un futur employeur pour l'entretien d'embauche qui aboutira
                     (nous l'espérons…) à la signature du contrat.
                 </p>
-                <p>
-                    Pour mémoire, la règlementation de la plupart des diplômes du travail social subordonne l'accès à la
+                <p>Pour mémoire, la règlementation de la plupart des diplômes du travail social subordonne l'accès à la
                     formation à la passation d'épreuves d'admission : le contrat d'apprentissage ne pourra être finalisé
                     qu'une fois l'admission prononcée.
                 </p>
-                <p>
-                    Plusieurs cas de figure :
-                </p>
-                <ul>
-                    <li>vous recherchez un employeur</li>
-                    <li>vous avez déjà une proposition d'embauche</li>
-                    <li>vous avez passé les épreuves d'admission</li>
-                    <li>vous n'avez pas passé les épreuves</li>
+                <p>Plusieurs cas de figure:</p>
+                <ul class="list-page paragraph">
+                    <li><span>vous recherchez un employeur</span></li>
+                    <li><span>vous avez déjà une proposition d'embauche</span></li>
+                    <li><span>vous avez passé les épreuves d'</span></li>
+                    <li><span>vous n'avez pas passé les épreuves</span></li>
                 </ul>
             </div>
         </div>
         <div class="row">
-            <div class="col-md-10 offset-1 my-5">
+            <div class="col-md-10 offset-1 my-md-2">
+                <h2 class=" mb-5 style-subtitle">Les conseils pour la recherche d'un employeur <i class="far fa-thumbs-up"></i></h2>
 
-                <h2 class=" mb-5 style-subtitle">Les conseils pour la recherche d'un employeur</h2>
-
-                <p>
-                    Il n'y a pas de secret ! Vos motivations, votre dynamisme seront les alliés de votre expérience,
+                <p>Il n'y a pas de secret ! Vos motivations, votre dynamisme seront les alliés de votre expérience,
                     de votre carnet d'adresses et de vos relations. En tentant des candidatures spontanées, en répondant
                     à des annonces, vous constaterez probablement chez vos interlocuteurs un degré d'information
                     variable, des incompréhensions ou des difficultés sur lesquelles vous n'avez pas de prise.
                     Ne vous découragez pas !
                 </p>
 
-                <p>
-                    S'il n'existe pas à proprement parler d'équivalent de "bourse de l'apprentissage" dans les
+                <p>S'il n'existe pas à proprement parler d'équivalent de "bourse de l'apprentissage" dans les
                     professions du travail social, vous pouvez vous mettre en lien avec le CFA pour faire part de votre
                     recherche de contrat. Sans baguette magique, le CFA fait tout son possible pour mettre en
                     correspondance les offres et les demandes, dès qu'elles sont communiquées. Les propositions de
@@ -52,16 +49,14 @@
                     octobre/novembre.
                 </p>
 
-                <p>
-                    Dès le printemps, vous pouvez commencer à cibler le type de structures qui correspond à votre projet.
+                <p>Dès le printemps, vous pouvez commencer à cibler le type de structures qui correspond à votre projet.
                     Le CFA peut vous guider dans votre démarche, mais vous restez maître de votre stratégie. Vous
                     pourrez commencer à prospecter auprès des établissements, services ou autres structures
                     (associations, collectivités territoriales, etc.), utiliser des sites, blogs et forums disponibles
                     pour faire circuler votre demande. Soyez enthousiastes mais pas ingénus !
                 </p>
 
-                <p>
-                    En préalable, l'élaboration de votre curriculum vitæ et d'une lettre de motivation est une étape
+                <p>En préalable, l'élaboration de votre curriculum vitæ et d'une lettre de motivation est une étape
                     primordiale dans la mise en valeur de votre candidature.
                     Se mettre en valeur, c'est tirer parti de ses expériences, savoir reconnaître et distinguer
                     les ressources dont on est porteur, sélectionner les savoir-faire qui peuvent intéresser un
@@ -71,29 +66,25 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-md-10 offset-1 my-5">
-                <h2 class="mb-5 style-subtitle">Les épreuves d'admission</h2>
-                <p>
-                    Excepté pour le BPJEPS, le BTS ESF et le DE CESF, l'accès à la formation nécessite d'être reçu à
+            <div class="col-md-10 offset-1 my-md-2">
+                <h2 class="mb-5 style-subtitle">Les épreuves d'admission <i class="far fa-check-circle"></i></h2>
+                <p>Excepté pour le BPJEPS, le BTS ESF et le DE CESF, l'accès à la formation nécessite d'être reçu à
                     des épreuves d'admission qui comportent généralement une épreuve écrite et une ou deux épreuves
                     orales. Quel que soit le statut du candidat (étudiant, situation d'emploi), les épreuves d'admission
                     sont de même nature et s'inscrivent dans les mêmes règlements d'admission.
                 </p>
-                <p>
-                    Les inscriptions aux épreuves d'admission sont ouvertes dans une période ordinaire qui s'étend
+                <p>Les inscriptions aux épreuves d'admission sont ouvertes dans une période ordinaire qui s'étend
                     généralement d'octobre à décembre (voir les dates sur les sites des établissements de formation en
                     travail social), pour une passation des épreuves écrites en janvier-février, suivies des épreuves
                     orales étalées entre mars et mai. Les commissions d'admission, statuant généralement vers la fin mai,
                     détermineront la liste principale et la liste complémentaire des candidats reçus.
                 </p>
-                <p>
-                    Ces épreuves s'adressent à des candidats sans distinction de statut. Cependant, la règlementation
+                <p>Ces épreuves s'adressent à des candidats sans distinction de statut. Cependant, la règlementation
                     propre à l'apprentissage permet aux futurs apprentis de bénéficier de conditions spécifiques :
                 </p>
                 
-                <h3>Exemple 1:</h3>
-                <p>
-                    Vous n'aviez pas retiré de dossier d'inscription aux épreuves d'admission dans la période
+                <h3 class="style-title-3">Exemple 1:</h3>
+                <p>Vous n'aviez pas retiré de dossier d'inscription aux épreuves d'admission dans la période
                     ordinaire, mais entretemps une embauche en contrat d'apprentissage vous a été proposée.
                     Or, l'article L6222-12 du Code du travail indique que sauf dérogation, un contrat
                     d'apprentissage peut être signé dans une période n'excédant pas trois mois avant ou après
@@ -107,17 +98,15 @@
                     épreuves.
                 </p>
                    
-                <h3>Exemple 2:</h3>
-                <p>
-                    Vous aviez passé les épreuves d'admission dans la période ordinaire, mais vous ne faisiez
+                <h3 class="style-title-3">Exemple 2:</h3>
+                <p>Vous aviez passé les épreuves d'admission dans la période ordinaire, mais vous ne faisiez
                     partie ni de la liste principale, ni de la liste complémentaire. Cependant, si vous avez eu
                     au moins la moyenne, vous avez la possibilité d'entrer en formation par l'apprentissage et
                     pouvez signer un contrat.
                 </p>
                     
-                <h3>Exemple 3:</h3>
-                <p>
-                    Vous aviez passé les épreuves d'admission dans la période ordinaire, mais vous n'avez pas
+                <h3 class="style-title-3">Exemple 3:</h3>
+                <p>Vous aviez passé les épreuves d'admission dans la période ordinaire, mais vous n'avez pas
                     eu la moyenne. Toutefois, si vous obtenez une promesse d'embauche, vous aurez la possibilité
                     de repasser les épreuves écrites et/ou orales qui vous permettront, en cas de réussite, de
                     finaliser votre contrat.
@@ -125,27 +114,21 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-md-10 offset-1 my-5">
-                <h2 class="mb-5 style-subtitle">La signature du contrat</h2>
-                <p>
-                    Vous avez réussi les épreuves d'admission…
-                </p>
-                <p>
-                    Vous avez trouvé l'employeur qui va vous accompagner dans votre projet professionnel…
-                </p>
-                <p>
-                    Il ne reste plus qu'à finaliser le contrat : c'est une démarche administrative qui s'effectue en
-                    remplissant le formulaire Cerfa FA13, à l'aide de sa notice FA14.
-                </p>
-                <p>
-                    Chacune des parties remplit les rubriques le concernant : "L'employeur", "L'apprenti",
-                    "Le maître d'apprentissage", "Le contrat".
-                </p>
-                <p>
-                    Après signature par l'apprenti et l'employeur, celui-ci adressera le contrat rempli au CFA qui
-                    complètera la rubrique "La formation" et se chargera du suivi de la procédure d'enregistrement
-                    auprès des autorités concernées (CCI ou Direccte).
-                </p>
+            <div class="col-md-10 offset-1 my-md-2">
+                <h2 class="mb-5 style-subtitle">La signature du contrat <i class="fas fa-pencil-alt"></i></h2>
+                <ul class="list-page paragraph number">
+                    <li><span>Vous avez réussi les épreuves d'admission…</span></li>
+                    <li><span>Vous avez trouvé l'employeur qui va vous accompagner dans votre projet professionnel…</span></li>
+                    <li><span>Il ne reste plus qu'à finaliser le contrat : c'est une démarche administrative qui s'effectue en
+                            remplissant le formulaire Cerfa FA13, à l'aide de sa notice FA14.</span></li>
+                    <li><span>Chacune des parties remplit les rubriques le concernant : "L'employeur", "L'apprenti",
+                            "Le maître d'apprentissage", "Le contrat".</span>
+                    </li>
+                    <li><span>Après signature par l'apprenti et l'employeur, celui-ci adressera le contrat rempli au CFA qui
+                        complètera la rubrique "La formation" et se chargera du suivi de la procédure d'enregistrement
+                        auprès des autorités concernées (CCI ou Direccte).</span>
+                    </li>
+                </ul>
             </div>
         </div>
     </div>

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -290,6 +290,10 @@ footer {
   margin-bottom: 2em;
 }
 
+.number {
+  list-style-type: decimal;
+}
+
 /** Formation **/
 
 .title-formation {


### PR DESCRIPTION
pour l'icon de la partie signature 
celui-ci ne passe pas <i class="fas fa-pen-nib"></i> (stylo plume)
alors que celui-ci passe <i class="fas fa-pencil-alt"></i> (crayon de papier)
Et je ne sais pas pourquoi.